### PR TITLE
Added a tips tutorial to use 'rsync'.

### DIFF
--- a/src/mdx-pages/part1/express-api.fr.mdx
+++ b/src/mdx-pages/part1/express-api.fr.mdx
@@ -445,6 +445,24 @@ Voici un example de ce qui devrait être affiché dans la console à chaque requ
 GET counter : 2
 ```
 
+### 🤝 Tips
+La commande 'rsync' permet de copier la solution de votre Exercice 1.1 dans un nouveau répertoire tout en omettant les fichiers mentionnés dans votre **`/.gitignore`**, tel que **`/node_modules/`**. 
+En effet, il est déconseillé de copier-coller ces fichiers, qui peuvent être très volumineux.
+```bash
+mkdir exercices/1.2/
+rsync -av --exclude-from='exercices/1.1/basic-ts-api-boilerplate/.gitignore' exercices/1.1/ exercices/1.2/
+```
+
+Pour installer **`rsync`** sur Ubuntu ou Debian : 
+```bash
+sudo apt install rsync
+```
+
+Pour installer **`rsync`** sur Windows : 
+Rendez vous sur https://repo.msys2.org/msys/x86_64/ et téléchargez les dernières versions de **`libxxhash-0.8.1-1-x86_64.pkg.tar.zst`** et **`rsync-3.3.0-1-x86_64.pkg.tar.zst`**.
+Décompressez les, copiez les fichiers **`rsync.exe`** et **`msys-xxhash-0.dll`** des répertoires **`usr\bin`** de leur archive respective, et collez les vers le répertoire **`C:\Program Files\Git\mingw64\bin`** .
+(source : https://www.jbnet.fr/systeme/windows/windows-installer-rsync-avec-git-bash.html )
+
 Veuillez faire un **`commit`** de votre code avec le message suivant : **`new: ex1.2`**.
 
 #### 🤝 Tips


### PR DESCRIPTION
rsync allows you to copy a folder by omitting the files mentioned in .gitignore. Useful for starting from the solution of an exercise in a new folder, by copying the project without copying and pasting the nodes_module