### PR TITLE
resolve issue #10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myjscourse",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "private": true,
   "description": "Learn JavaScript & Node.js",
   "author": "e-baron",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myjscourse",
-  "version": "4.0.12",
+  "version": "4.0.13",
   "private": true,
   "description": "Learn JavaScript & Node.js",
   "author": "e-baron",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,9 @@
     "remark-emoji": "^2.2.0",
     "remark-gfm": "^3.0.1",
     "sass": "^1.32.8",
-    "theme-ui": "^0.6.2"
+    "theme-ui": "^0.6.2",
+    "axios": "^1.7.7",
+    "jszip": "^3.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/download-git-folder-link/DownloadGitFolder.js
+++ b/src/components/download-git-folder-link/DownloadGitFolder.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import JSZip from 'jszip';
+import axios from 'axios';
+
+const DownloadGitFolder = ({ repoUrl, folderPath }) => {
+ 
+      const downloadFolder = async () => {
+        const [owner, repo] = repoUrl.split('/').slice(-2);
+        const apiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${folderPath}`;
+    
+        const zip = new JSZip();
+    
+        const addFolderToZip = async (url, zipFolder) => {
+          const response = await axios.get(url, {
+            headers: { Accept: 'application/vnd.github.v3+json' },
+          });
+    
+          for (const file of response.data) {
+            if (file.type === 'file') {
+              const fileResponse = await axios.get(file.download_url, {
+                responseType: 'arraybuffer',
+              });
+              zipFolder.file(`${file.name}`, fileResponse.data);
+            } else if (file.type === 'dir') {
+              const newFolder = zipFolder.folder(file.name);
+              
+              if (newFolder instanceof JSZip) {
+                await addFolderToZip(file.url, newFolder);
+              }
+            }
+          }
+        };
+    
+        try {
+          await addFolderToZip(apiUrl, zip.folder(folderPath));
+    
+          const content = await zip.generateAsync({ type: 'blob' });
+          const link = document.createElement('a');
+          link.href = URL.createObjectURL(content);
+          link.download = `${folderPath}.zip`;
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+        } catch (error) {
+          console.error('Error downloading folder:', error);
+        }
+      };
+    
+     return <span style={{ cursor: 'pointer', color: 'blue', textDecoration: 'underline' }} onClick={downloadFolder}>Download {folderPath}</span>;
+
+};
+
+export default DownloadGitFolder;

--- a/src/mdx-pages/part1/express-api.fr.mdx
+++ b/src/mdx-pages/part1/express-api.fr.mdx
@@ -439,6 +439,7 @@ Veuillez créer un middleware qui permette d'enregistrer et d'afficher dans la c
 Vous devez enregistrer, depuis le démarrage du serveur, le nombre de requêtes **`GET`** faites à votre API.
 
 Veuillez repartir du code de la solution de votre Exercice 1.1 en créant un nouveau projet dans votre repo git dans **`/exercises/1.2`**.  
+Vous pouvez télécharger la solution de l'Exercice 1.1 en cliquant sur <DownloadGitFolder repoUrl="https://github.com/e-vinci/js-exercises" folderPath="1.1"/>
 
 Voici un example de ce qui devrait être affiché dans la console à chaque requête vers votre API :
 ```bash

--- a/src/mdx-pages/part2/fetch.fr.mdx
+++ b/src/mdx-pages/part2/fetch.fr.mdx
@@ -447,7 +447,7 @@ Content-Type: application/json
 
 Ici, c'est le JS/TS à rajouter dans la fonction **`addPizza`** de **`App`** qui doit, permettre de récupérer les données de la pizza à créer et faire un **`fetch`** de l'opération de création offerte par l'API.
 
-Pour arriver à nos fins, veuillez mettre à jour la fonction `addPizza` dans `Main` :
+Pour arriver à nos fins, veuillez mettre à jour la fonction `addPizza` dans `App` :
 
 ```tsx numbered highlighting="2-23"
 const addPizza = async (newPizza: NewPizza) => {
@@ -475,8 +475,6 @@ const addPizza = async (newPizza: NewPizza) => {
     }
   };
 }
-
-export default AddPizzaPage;
 ```
 
 Pour la nouveauté et le **`fetch`** :

--- a/src/mdx-pages/part3/auths-api.fr.mdx
+++ b/src/mdx-pages/part3/auths-api.fr.mdx
@@ -1184,7 +1184,7 @@ Nous avons simplement chaîné les réponses à faire au client seulement une fo
 Notons que nous avons ajouté un commentaire pour désactiver la règle **`@typescript-eslint/no-misused-promises`**. En effet, dans Express V4, les fonctions asynchrones ne sont pas pleinement supportées en TypeScript (seul le type de retour **`void`** pour **`RequestHandler`** est autorisé). Dans Express V5, ce problème a été résolu, mais V5 est toujours en version bêta. Par conséquent, la règle ESLint **`no-misused-promises`** est désactivée.
 
 Veuillez vérifier que votre application fonctionne correctement.  
-Via l'IHM, veuillez faire un register d'un nouvel utilisateur.  
+Via l'Rest Client, veuillez faire un register d'un nouvel utilisateur.  
 Au niveau de l'API, allez voir le contenu du nouveau fichier **`/data/users.json`**. Les passwords devraient maintenant être hachés, comme par exemple :
 
 ```json

--- a/src/templates/mdx-pages.js
+++ b/src/templates/mdx-pages.js
@@ -31,6 +31,7 @@ import {
   PathViewer,
   PathViewerItem,
 } from '../components/path-viewer/path-viewer.js';
+import DownloadGitFolder from '../components/download-git-folder-link/DownloadGitFolder.js';
 
 const shortcodes = {
   Link,
@@ -54,6 +55,7 @@ const shortcodes = {
   InternalPageTitle,
   PathViewer,
   PathViewerItem,
+  DownloadGitFolder,
 };
 
 export default function PageTemplate({ data: { mdx, allImages }, children }) {


### PR DESCRIPTION
I added a React component that can be reused to download any folder from a github repo.

For the example, I used this component to allow the client to download the following folder: https://github.com/e-vinci/js-exercises/tree/main/1.1/

Here is the code that I had to add for this example, you can see that you have to give the component the url of a git repo as well as the path of the folder that you want to download : 

![demo2-pull-request](https://github.com/user-attachments/assets/b33edaee-c55d-4a80-a2f2-d10666a0392e)


And here is the result, when you click on the link a .zip file is downloaded : 

![demo-pull-request](https://github.com/user-attachments/assets/1f28a577-a0f6-4587-96c5-296b19565283)


NB: Github API allows a limited number of requests per user. I was faced with the following error message: 
_"API rate limit exceeded for **'my ip adress'**. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)"_. This could be a problem if all students click on the link at the same time from the school wifi